### PR TITLE
Analysis

### DIFF
--- a/notebooks/preparation/animes_dataset_feature_engineering.ipynb
+++ b/notebooks/preparation/animes_dataset_feature_engineering.ipynb
@@ -3434,6 +3434,27 @@
    "execution_count": 32
   },
   {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-24T23:49:24.776322Z",
+     "start_time": "2025-09-24T23:49:23.037052Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_parquet(\"../../data/processed/animes_processed.parquet\")\n",
+    "df = df.rename(columns={\n",
+    "    \"uid\": \"anime_uid\"\n",
+    "})\n",
+    "df.to_parquet(\"../../data/processed/animes_final.parquet\", index=False)"
+   ],
+   "id": "89609c708683a623",
+   "outputs": [],
+   "execution_count": 1
+  },
+  {
    "metadata": {},
    "cell_type": "markdown",
    "source": [


### PR DESCRIPTION
This pull request adds a new code cell to the `animes_dataset_feature_engineering.ipynb` notebook to further process the anime dataset. The new cell loads a Parquet file, renames the `uid` column to `anime_uid`, and saves the result to a new Parquet file. This helps standardize column naming and prepares the dataset for downstream tasks.

Data processing and feature engineering:

* Added a code cell that loads `animes_processed.parquet`, renames the `uid` column to `anime_uid`, and saves the DataFrame as `animes_final.parquet` for improved consistency in dataset structure.